### PR TITLE
Add CI : auth_spawn_rust and update toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
       run: make all-via-docker
     - name: Run auth_rust tests
       run: cd tests/auth_rust && bash run.sh
+    - name: Install ckb-debugger
+      run: cd tests/auth_spawn_rust && make install
     - name: Run auth_spawn_rust tests
       run: cd tests/auth_spawn_rust && make all
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,3 +16,6 @@ jobs:
       run: make all-via-docker
     - name: Run auth_rust tests
       run: cd tests/auth_rust && bash run.sh
+    - name: Run auth_spawn_rust tests
+      run: cd tests/auth_spawn_rust && make all
+

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ TARGET := riscv64-unknown-linux-gnu
 CC := $(TARGET)-gcc
 LD := $(TARGET)-gcc
 OBJCOPY := $(TARGET)-objcopy
-CFLAGS := -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -I deps/ckb-c-stdlib-2023 -I deps/ckb-c-stdlib-2023/libc -I deps/ckb-c-stdlib-2023/molecule -I c -I build -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -Wno-dangling-pointer -Wno-array-bounds -g
+CFLAGS := -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -I deps/ckb-c-stdlib-2023 -I deps/ckb-c-stdlib-2023/libc -I deps/ckb-c-stdlib-2023/molecule -I c -I build -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -Wno-dangling-pointer -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 SECP256K1_SRC_20210801 := deps/secp256k1-20210801/src/ecmult_static_pre_context.h
-AUTH_CFLAGS := $(CFLAGS) -I deps/mbedtls/include
+AUTH_CFLAGS := $(CFLAGS) -I deps/mbedtls/include -Wno-array-bounds
 
 # RSA/mbedtls
 CFLAGS_MBEDTLS := $(subst ckb-c-std-lib,ckb-c-stdlib-2023,$(CFLAGS)) -I deps/mbedtls/include

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGET := riscv64-unknown-linux-gnu
 CC := $(TARGET)-gcc
 LD := $(TARGET)-gcc
 OBJCOPY := $(TARGET)-objcopy
-CFLAGS := -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -I deps/ckb-c-stdlib-2023 -I deps/ckb-c-stdlib-2023/libc -I deps/ckb-c-stdlib-2023/molecule -I c -I build -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -g
+CFLAGS := -fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -nostartfiles -fvisibility=hidden -fdata-sections -ffunction-sections -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -I deps/ckb-c-stdlib-2023 -I deps/ckb-c-stdlib-2023/libc -I deps/ckb-c-stdlib-2023/molecule -I c -I build -Wall -Werror -Wno-nonnull -Wno-nonnull-compare -Wno-unused-function -Wno-dangling-pointer -Wno-array-bounds -g
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections
 SECP256K1_SRC_20210801 := deps/secp256k1-20210801/src/ecmult_static_pre_context.h
 AUTH_CFLAGS := $(CFLAGS) -I deps/mbedtls/include
@@ -12,8 +12,8 @@ CFLAGS_MBEDTLS := $(subst ckb-c-std-lib,ckb-c-stdlib-2023,$(CFLAGS)) -I deps/mbe
 LDFLAGS_MBEDTLS := $(LDFLAGS)
 PASSED_MBEDTLS_CFLAGS := -O3 -fPIC -nostdinc -nostdlib -DCKB_DECLARATION_ONLY -I ../../ckb-c-stdlib-2023/libc -fdata-sections -ffunction-sections
 
-# docker pull nervos/ckb-riscv-gnu-toolchain:gnu-bionic-20191012
-BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:aae8a3f79705f67d505d1f1d5ddc694a4fd537ed1c7e9622420a470d59ba2ec3
+# docker pull nervos/ckb-riscv-gnu-toolchain:gnu-jammy-20230214
+BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:d3f649ef8079395eb25a21ceaeb15674f47eaa2d8cc23adc8bcdae3d5abce6ec
 
 all:  build/secp256k1_data_info_20210801.h $(SECP256K1_SRC_20210801) deps/mbedtls/library/libmbedcrypto.a build/auth build/always_success
 

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -8,5 +8,5 @@ auth-spawn-success:
 	${CKB_DEBUGGER} --tx-file=tx.json -s lock
 
 install:
-	cargo install --locked --rev 5077c6c4 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+	cargo install --locked --rev c7b0cd60 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -8,5 +8,5 @@ auth-spawn-success:
 	${CKB_DEBUGGER} --tx-file=tx.json -s lock
 
 install:
-	cargo install --locked --rev c7b0cd60 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+	cargo install --locked --branch ckb2023 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -1,9 +1,13 @@
 CKB_DEBUGGER ?= ckb-debugger
 
 all: \
+	install \
 	auth-spawn-success
 
 auth-spawn-success:
 	cargo run --bin auth-spawn-success > tx.json
 	${CKB_DEBUGGER} --tx-file=tx.json -s lock
+
+install:
+	cargo install --locked --rev 02f4656 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -1,7 +1,6 @@
 CKB_DEBUGGER ?= ckb-debugger
 
 all: \
-	install \
 	auth-spawn-success
 
 auth-spawn-success:
@@ -9,5 +8,5 @@ auth-spawn-success:
 	${CKB_DEBUGGER} --tx-file=tx.json -s lock
 
 install:
-	cargo install --locked --rev 02f4656 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+	cargo install --locked --rev 5077c6c4 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 

--- a/tests/auth_spawn_rust/templates/auth-spawn-success.json
+++ b/tests/auth_spawn_rust/templates/auth-spawn-success.json
@@ -49,7 +49,7 @@
             },
             "type": "{{ def_type secp256k1_data }}"
           },
-          "data": "0x{{ data ../../../build/secp256k1_data }}"
+          "data": "0x{{ data ../../../build/secp256k1_data_20210801 }}"
         }
       ],
       "header_deps": []


### PR DESCRIPTION
* Add CI for auth_spawn_rust
* Update toolchain to nervos/ckb-riscv-gnu-toolchain:gnu-jammy-20230214

There seems to be a problem with this [PR](https://github.com/cryptape/ckb-auth/pull/1), so resubmit it here.