### PR TITLE
add monero support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,12 @@ jobs:
         wget -O "$tarball" https://download.litecoin.org/litecoin-0.21.2.2/linux/litecoin-0.21.2.2-x86_64-linux-gnu.tar.gz
         tar xvzf "$tarball"
         sudo cp -r litecoin-*/* /usr/local
+    - name: Install monero wallet cli for tests
+      run: |
+        tarball=monero-wallet-cli.tar.gz
+        wget -O "$tarball" https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.2.2.tar.bz2
+        tar xvaf "$tarball"
+        sudo cp -r monero-*/* /usr/local/bin/
     - name: Build contract
       run: make all-via-docker
     - name: Run auth_rust tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 
 [submodule "deps/ed25519"]
 	path = deps/ed25519
-	url = https://github.com/nervosnetwork/ed25519.git
+	url = https://github.com/contrun/ed25519.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 
 [submodule "deps/ed25519"]
 	path = deps/ed25519
-	url = https://github.com/contrun/ed25519.git
+	url = https://github.com/nervosnetwork/ed25519.git

--- a/c/auth.c
+++ b/c/auth.c
@@ -475,11 +475,12 @@ int validate_signature_monero(void *prefilled_data, const uint8_t *sig,
     CHECK2(sig_len == MONERO_DATA_SIZE, ERROR_INVALID_ARG);
 
     uint8_t *mode_ptr = (uint8_t *)sig + MONERO_SIGNATURE_SIZE;
-    CHECK2(*mode_ptr != 0 || *mode_ptr != 1, ERROR_INVALID_ARG);
+    // We only support using spend key to sign transactions.
+    CHECK2(*mode_ptr == 0, ERROR_INVALID_ARG);
 
     uint8_t *spend_pubkey = mode_ptr + sizeof(*mode_ptr);
     uint8_t *view_pubkey = spend_pubkey + MONERO_PUBKEY_SIZE;
-    uint8_t *pubkey = *mode_ptr == 0 ? spend_pubkey : view_pubkey;
+    uint8_t *pubkey = spend_pubkey;
 
     uint8_t hash[MONERO_KECCAK_SIZE];
     get_monero_message_hash(hash, spend_pubkey, view_pubkey, *mode_ptr, msg,

--- a/c/auth.c
+++ b/c/auth.c
@@ -3,6 +3,8 @@
 #include "mbedtls/md_internal.h"
 #include "mbedtls/memory_buffer_alloc.h"
 #include "ed25519.h"
+#include "ge.h"
+#include "sc.h"
 
 // configuration for secp256k1
 #define ENABLE_MODULE_EXTRAKEYS
@@ -63,6 +65,10 @@
 #define RIPEMD160_SIZE 20
 #define SCHNORR_SIGNATURE_SIZE (32 + 64)
 #define SCHNORR_PUBKEY_SIZE 32
+#define MONERO_PUBKEY_SIZE 32
+#define MONERO_SIGNATURE_SIZE 64
+#define MONERO_DATA_SIZE (MONERO_SIGNATURE_SIZE + 1 + MONERO_PUBKEY_SIZE * 2)
+#define MONERO_KECCAK_SIZE 32
 
 enum AuthErrorCodeType {
     ERROR_NOT_IMPLEMENTED = 100,
@@ -356,6 +362,137 @@ int validate_signature_cardano(void *prefilled_data, const uint8_t *sig,
     blake2b_init(&ctx, BLAKE2B_BLOCK_SIZE);
     blake2b_update(&ctx, cardano_data.public_key,
                    sizeof(cardano_data.public_key));
+    blake2b_final(&ctx, pubkey_hash, sizeof(pubkey_hash));
+
+    memcpy(output, pubkey_hash, BLAKE160_SIZE);
+    *output_len = BLAKE160_SIZE;
+exit:
+    return err;
+}
+
+// Write size_t integer as a varint to the dest.
+// See
+// https://github.com/monero-project/monero/blob/e06129bb4d1076f4f2cebabddcee09f1e9e30dcc/src/common/varint.h#L64-L79
+size_t write_varint(uint8_t *dest, size_t n) {
+    uint8_t *ptr = dest;
+    /* Make sure that there is one after this */
+    while (n >= 0x80) {
+        *ptr = ((uint8_t)(n)&0x7f) | 0x80;
+        ptr++;
+        n >>= 7; /* I should be in multiples of 7, this should just get the next
+                    part */
+    }
+    /* writes the last one to dest */
+    *ptr = (uint8_t)(n);
+    ptr++;
+    return ptr - dest;
+}
+
+// Get monero hash digest from message.
+// See
+// https://github.com/monero-project/monero/blob/e06129bb4d1076f4f2cebabddcee09f1e9e30dcc/src/wallet/wallet2.cpp#L12519-L12538
+void get_monero_message_hash(uint8_t hash[MONERO_KECCAK_SIZE],
+                             uint8_t *spend_pubkey, uint8_t *view_pubkey,
+                             uint8_t mode, const uint8_t *msg, size_t msg_len) {
+    const char MONERO_HASH_KEY_MESSAGE_SIGNING[] = "MoneroMessageSignature";
+    SHA3_CTX ctx;
+    keccak_init(&ctx);
+
+    keccak_update(&ctx, (uint8_t *)MONERO_HASH_KEY_MESSAGE_SIGNING,
+                  sizeof(MONERO_HASH_KEY_MESSAGE_SIGNING));  // includes NUL
+    keccak_update(&ctx, spend_pubkey, MONERO_PUBKEY_SIZE);
+    keccak_update(&ctx, view_pubkey, MONERO_PUBKEY_SIZE);
+    keccak_update(&ctx, &mode, sizeof(mode));
+
+    uint8_t len_buf[(sizeof(size_t) * 8 + 6) / 7];
+    size_t written_bytes = write_varint((uint8_t *)len_buf, msg_len);
+    keccak_update(&ctx, (uint8_t *)len_buf, written_bytes);
+
+    keccak_update(&ctx, (uint8_t *)msg, msg_len);
+
+    keccak_final(&ctx, (uint8_t *)hash);
+}
+
+void monero_hash_to_scalar(uint8_t *msg, size_t msg_len, uint8_t *key,
+                           uint8_t *comm, uint8_t scalar[32]) {
+    uint8_t state[200];
+    SHA3_CTX sha3_ctx;
+
+    keccak_init(&sha3_ctx);
+    keccak_update(&sha3_ctx, msg, msg_len);
+    keccak_update(&sha3_ctx, key, 32);
+    keccak_update(&sha3_ctx, comm, 32);
+    keccak_final(&sha3_ctx, state);
+    memcpy(scalar, &state, 32);
+    sc_reduce32(scalar);
+}
+
+// See
+// https://github.com/monero-project/monero/blob/e06129bb4d1076f4f2cebabddcee09f1e9e30dcc/src/crypto/crypto.cpp#L319-L341
+int ed25519_verify_monero(const unsigned char *signature,
+                          const unsigned char *message, size_t message_len,
+                          const unsigned char *public_key) {
+    ge_p2 tmp2;
+    ge_p3 tmp3;
+    uint8_t c[32];
+    uint8_t comm[32];
+    uint8_t *sig_c = (uint8_t *)signature;
+    uint8_t *sig_r = sig_c + 32;
+    uint8_t zero[32];
+    uint8_t sig_c_neg[32];
+
+    if (sc_check(sig_c) != 0 || sc_check(sig_r) != 0 || !sc_isnonzero(sig_c)) {
+        return 0;
+    }
+    // TODO: implement ge_frombytes_vartime instead of using
+    // ge_frombytes_negate_vartime and then multiple the result with a negative
+    // scalar
+    sc_0(zero);
+    sc_sub(sig_c_neg, zero, sig_c);
+    if (ge_frombytes_negate_vartime(&tmp3, public_key) != 0) {
+        return 0;
+    }
+    ge_double_scalarmult_vartime(&tmp2, sig_c_neg, &tmp3, sig_r);
+    ge_tobytes(comm, &tmp2);
+
+    static const uint8_t infinity[32] = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    if (memcmp(&comm, &infinity, 32) == 0) return 0;
+    monero_hash_to_scalar((uint8_t *)message, message_len,
+                          (uint8_t *)public_key, comm, c);
+    sc_sub(c, c, sig_c);
+    return sc_isnonzero((const uint8_t *)c) == 0;
+}
+
+int validate_signature_monero(void *prefilled_data, const uint8_t *sig,
+                              size_t sig_len, const uint8_t *msg,
+                              size_t msg_len, uint8_t *output,
+                              size_t *output_len) {
+    int err = 0;
+
+    CHECK2(msg_len == BLAKE2B_BLOCK_SIZE, ERROR_INVALID_ARG);
+    CHECK2(sig_len == MONERO_DATA_SIZE, ERROR_INVALID_ARG);
+
+    uint8_t *mode_ptr = (uint8_t *)sig + MONERO_SIGNATURE_SIZE;
+    CHECK2(*mode_ptr != 0 || *mode_ptr != 1, ERROR_INVALID_ARG);
+
+    uint8_t *spend_pubkey = mode_ptr + sizeof(*mode_ptr);
+    uint8_t *view_pubkey = spend_pubkey + MONERO_PUBKEY_SIZE;
+    uint8_t *pubkey = *mode_ptr == 0 ? spend_pubkey : view_pubkey;
+
+    uint8_t hash[MONERO_KECCAK_SIZE];
+    get_monero_message_hash(hash, spend_pubkey, view_pubkey, *mode_ptr, msg,
+                            msg_len);
+
+    int suc = ed25519_verify_monero(sig, hash, sizeof(hash), pubkey);
+    CHECK2(suc == 1, ERROR_EXEC_INVALID_SIG);
+
+    blake2b_state ctx;
+    uint8_t pubkey_hash[BLAKE2B_BLOCK_SIZE] = {0};
+    blake2b_init(&ctx, BLAKE2B_BLOCK_SIZE);
+    // TODO: find out the official way of get monero pubkey
+    blake2b_update(&ctx, mode_ptr, 1 + MONERO_PUBKEY_SIZE * 2);
     blake2b_final(&ctx, pubkey_hash, sizeof(pubkey_hash));
 
     memcpy(output, pubkey_hash, BLAKE160_SIZE);
@@ -765,6 +902,10 @@ __attribute__((visibility("default"))) int ckb_auth_validate(
         err = verify(pubkey_hash, signature, signature_size, message,
                      message_size, validate_signature_cardano, convert_copy);
         CHECK(err);
+    } else if (auth_algorithm_id == AuthAlgorithmIdMonero) {
+        err = verify(pubkey_hash, signature, signature_size, message,
+                     message_size, validate_signature_monero, convert_copy);
+        CHECK(err);
     } else if (auth_algorithm_id == AuthAlgorithmIdOwnerLock) {
         CHECK2(is_lock_script_hash_present(pubkey_hash), ERROR_MISMATCHED);
         err = 0;
@@ -900,3 +1041,7 @@ exit:
 #undef ARGV_MESSAGE
 #undef ARGV_PUBKEY_HASH
 }
+
+
+
+

--- a/c/auth.c
+++ b/c/auth.c
@@ -487,7 +487,7 @@ int validate_signature_monero(void *prefilled_data, const uint8_t *sig,
                             msg_len);
 
     int suc = ed25519_verify_monero(sig, hash, sizeof(hash), pubkey);
-    CHECK2(suc == 1, ERROR_EXEC_INVALID_SIG);
+    CHECK2(suc == 1, ERROR_SPAWN_INVALID_SIG);
 
     blake2b_state ctx;
     uint8_t pubkey_hash[BLAKE2B_BLOCK_SIZE] = {0};

--- a/c/ckb_auth.h
+++ b/c/ckb_auth.h
@@ -36,6 +36,7 @@ enum AuthAlgorithmIdType {
     AuthAlgorithmIdIso97962 = 9,
     AuthAlgorithmIdLitecoin = 10,
     AuthAlgorithmIdCardano = 11,
+    AuthAlgorithmIdMonero = 12,
     AuthAlgorithmIdOwnerLock = 0xFC,
 };
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -129,9 +129,17 @@ Key parameters:
 - pubkey: 32 compressed pubkey
 - pubkey hash: blake160 of pubkey
 
+#### Monero(algorithm_id=12)
+
+Key parameters:
+- signature: monero signature
+- mode: 1 byte hardcoded to 00 to indicate we are using spend key to sign transactions
+- spend key: 32 bytes of the public spend key
+- view key: 32 bytes of the public view key
+- pubkey hash: blake160 of (mode || spend key || view key)
+
 #### More blockchains Support Are Ongoing ...
 - Ripple
-- Monero
 - Solana
 
 ...

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -1,0 +1,131 @@
+# ckb-auth monero interoperability
+
+Ckb-auth library is able to verify a lot of blockchain signatures including the monero.
+We can use `monero-wallet-cli` (or other compatible wallet) to generate valid signatures and validate them on-chain with ckb-auth.
+
+A simple way to use monero signature algorithm to lock ckb cells
+is to sign the transaction hash (or maybe `sighash_all`, i.e. hashing all fields 
+including transaction hash and other witnesses in this input group)
+with `monero-wallet-cli`, and then leverage ckb-auth to check the validity of this signature.
+See [the docs](./auth.md) for more details.
+
+# Signing a transaction with monero-wallet-cli
+## Downloading the monero binaries
+The commands below download the official `monero` binaries (e.g. `monerod` for monero daemon,
+`monero-wallet-cli` for monero command line client) into the directory `/usr/local`.
+
+```
+tarball=monero-wallet-cli.tar.gz
+wget -O "$tarball" https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.2.2.tar.bz2
+tar xvaf "$tarball"
+sudo cp -r monero-*/* /usr/local/
+```
+
+## Setting up a monero wallet
+### Creating a new wallet
+You will need to create a new wallet to sign transactions with `monero-wallet-cli`.
+
+One option is to generate a all-new wallet by running
+```
+monero-wallet-cli --offline --generate-new-wallet ckb-auth-test-wallet
+```
+
+Just follow the instructions to create a new wallet.
+
+### Importing private keys into wallet file
+To import an account with address `41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc` into a wallet named `ckb-auth-test-wallet` non-interactively, we can first create a file which is to be used as the stdin of a following `monero-wallet-cli`.
+```
+cat <<EOF >commands
+41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc
+8ef26aced8b5f8e1e8ce63b6c75ac6ee41424242424242424242424242424202
+972874ae95f5c167285858141e940847398f9c246c7913c0d396b6d73b484105
+pw
+pw
+0
+N
+
+EOF
+```
+
+Here `8ef26aced8b5f8e1e8ce63b6c75ac6ee41424242424242424242424242424202` and `972874ae95f5c167285858141e940847398f9c246c7913c0d396b6d73b484105` are respectively the spend private key and view private key of this account.
+
+We can then run the following command to import this account.
+```
+monero-wallet-cli --offline --generate-from-keys ckb-auth-test-wallet < commands
+```
+
+## Obtaining address information
+
+See also [Creating a wallet in non-interactive mode using monero-wallet-cli? - Monero Stack Exchange](https://monero.stackexchange.com/questions/10385/creating-a-wallet-in-non-interactive-mode-using-monero-wallet-cli).
+
+Running `monero-wallet-cli --wallet-file ckb-auth-test-wallet --password pw --offline` to enter the interactive mode of
+monero command line wallet.
+
+```
+[wallet 41eBLj (no daemon)]: viewkey
+Wallet password:
+secret: 972874ae95f5c167285858141e940847398f9c246c7913c0d396b6d73b484105
+public: bbcb8c902571ae1a777f7f07a023ecc5e3d83ba624d4b0ffb7eff79e8b5d10bd
+[wallet 41eBLj (no daemon)]: spendkey
+Wallet password:
+secret: 8ef26aced8b5f8e1e8ce63b6c75ac6ee41424242424242424242424242424202
+public: 007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1
+[wallet 41eBLj (no daemon)]: address
+0  41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc  Primary address
+```
+
+## Getting the pubkey hash
+There is a flag `mode` for `monero-wallet-cli` to toggle whether to use spend key or view key to sign a message.
+The only valid values for `mode` are 0 and 1. 0 (default or set by passing parameter `--spend` to the rpc `sign`)
+represents that we used spend key to sign the message,
+while 1 (set by passing parameter `--view` to the rpc `sign`) represents that we used view key to sign the message.
+
+Currently, ckb-auth uses mode, spend public key, view public key to compute pubkey hash of monero account.
+To be more specific,
+
+```
+pubkey_hash = blake2b_256(mode || pub_spend_key || pub_view_key)
+```
+
+For example if the account we are using to sign messages is as above, i.e. it has
+public spend key `007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1` and
+public view key `bbcb8c902571ae1a777f7f07a023ecc5e3d83ba624d4b0ffb7eff79e8b5d10bd`.
+Then the pubkey hash `a55ec8bb5b93aaffefd754996cb097228839aad6` is just the blake2b 256 hash of `00007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1bbcb8c902571ae1a777f7f07a023ecc5e3d83ba624d4b0ffb7eff79e8b5d10bd`.
+
+## Signing message helloworld
+### Creating message file
+In order for `monero-wallet-cli` to sign a message, we need first create a message file.
+Normally the message the binary representation of a hash, we can create such binary file easily with
+
+```
+printf '%b' $(printf 4242424242424242424242424242424242424242424242424242424242424242 | fold -b2 | sed 's#^#\\x#') > message
+```
+Here `message` is a binary file with 32 repeated bytes of `0x42`. Change the command to suit your needs.
+
+### Signing the message
+We can sign a message by running
+```
+monero-wallet-cli --wallet-file ckb-auth-test-wallet --password pw sign message
+```
+
+Below is a sample output of the above command.
+
+```
+This is the command line monero wallet. It needs to connect to a monero
+daemon to work correctly.
+WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.
+
+Monero 'Fluorine Fermi' (v0.18.1.2-unknown)
+Logging to monero-wallet-cli.log
+Opened wallet: 41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc
+**********************************************************************
+Use the "help" command to see a simplified list of available commands.
+Use "help all" to see the list of all available commands.
+Use "help <command>" to see a command's documentation.
+**********************************************************************
+SigV2DXdetxj9qiRe6PHsch9EwZVutb1FFR38ubNuM9ef8YPYcnjAisLWo4sLZMoT3g4Z48VRD3xAUsk1EcfthWcxnayW
+```
+
+Stripping the prefix `SigV2` of `SigV2DXdetxj9qiRe6PHsch9EwZVutb1FFR38ubNuM9ef8YPYcnjAisLWo4sLZMoT3g4Z48VRD3xAUsk1EcfthWcxnayW`,
+we get the base58 representation of the signature. Note that monero's implementation of base58 is different from bitcoin's.
+See [monero-rs/base58-monero](https://github.com/monero-rs/base58-monero) for how to manipulate monero base58 data programatically.

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -44,7 +44,8 @@ Stripping prefix `SigV2`, this is the base64-encoded signature.
 
 ## Verify the signature with `verify` subcommand
 ```
-ckb-auth-cli monero verify -p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea`
+ckb-auth-cli monero verify -p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea -a 41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc -m spend
+-p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea
 ```
 This commands return zero if and only if verification succeeded.
 

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -9,6 +9,45 @@ including transaction hash and other witnesses in this input group)
 with `monero-wallet-cli`, and then leverage ckb-auth to check the validity of this signature.
 See [the docs](./auth.md) for more details.
 
+# Generate and verify transaction with ckb-auth-cli
+
+## Get the pub key hash with `parse` sub command.
+Here the argument given to `-a` is the address of monero account, while the argument given to `-m` refers to
+whether the spend key or view key is used to sign the transaction.
+```
+ckb-auth-cli monero parse -a 41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc -m spend
+```
+which outputs
+```
+a55ec8bb5b93aaffefd754996cb097228839aad6
+```
+## Get the message to sign with `generate` subcommand.
+```
+ckb-auth-cli monero generate -p a55ec8bb5b93aaffefd754996cb097228839aad6
+```
+which outputs the message to sign
+```
+157ea09579f09cf96307f6b23d6fd61c3cff123076d44c27e2e9bedf02135e87
+```
+## Sign the message with litecoin-cli
+Following the steps below to set up a monero wallet, save above message to a binary file,
+e.g. running `printf "$(printf 157ea09579f09cf96307f6b23d6fd61c3cff123076d44c27e2e9bedf02135e87 | fold -w 2 | xargs -n 1 printf '\\x%s')" > ckb-auth-test-message`
+to save it to `ckb-auth-test-message`. To sign this message, finally run
+```
+monero-wallet-cli --wallet-file ckb-auth-test-wallet --password pw sign ckb-auth-test-message
+```
+which outputs
+```
+SigV23ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea
+```
+Stripping prefix `SigV2`, this is the base64-encoded signature.
+
+## Verify the signature with `verify` subcommand
+```
+ckb-auth-cli monero verify -p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea`
+```
+This commands return zero if and only if verification succeeded.
+
 # Signing a transaction with monero-wallet-cli
 ## Downloading the monero binaries
 The commands below download the official `monero` binaries (e.g. `monerod` for monero daemon,

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -13,7 +13,7 @@ See [the docs](./auth.md) for more details.
 
 ## Get the pub key hash with `parse` sub command.
 Here the argument given to `-a` is the address of monero account, while the argument given to `-m` refers to
-whether the spend key or view key is used to sign the transaction.
+whether the spend key or view key is used to sign the transaction (only spend key mode is supported).
 ```
 ckb-auth-cli monero parse -a 41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc -m spend
 ```
@@ -114,17 +114,18 @@ public: 007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1
 ```
 
 ## Getting the pubkey hash
-There is a flag `mode` for `monero-wallet-cli` to toggle whether to use spend key or view key to sign a message.
-The only valid values for `mode` are 0 and 1. 0 (default or set by passing parameter `--spend` to the rpc `sign`)
-represents that we used spend key to sign the message,
-while 1 (set by passing parameter `--view` to the rpc `sign`) represents that we used view key to sign the message.
-
 Currently, ckb-auth uses mode, spend public key, view public key to compute pubkey hash of monero account.
 To be more specific,
 
 ```
 pubkey_hash = blake2b_256(mode || pub_spend_key || pub_view_key)
 ```
+
+Here `mode` indicates whether we are using the spend key or the view key.
+Although there are flags `--spend` and `--view` for `monero-wallet-cli` to toggle whether to
+use spend key or view key to sign a message. We only support signing transactions with spend key.
+Thus he only valid values for `mode` is 0, which
+represents that we used spend key to sign the message.
 
 For example if the account we are using to sign messages is as above, i.e. it has
 public spend key `007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1` and
@@ -146,7 +147,6 @@ We can sign a message with spend key by running
 ```
 monero-wallet-cli --wallet-file ckb-auth-test-wallet --password pw sign message
 ```
-Signing with view key is also possible by passing `--view` to the sign command.
 
 Below is a sample output of the above command.
 
@@ -171,7 +171,8 @@ we get the base58 representation of the signature. Note that monero's implementa
 See [monero-rs/base58-monero](https://github.com/monero-rs/base58-monero) for how to manipulate monero base58 data programatically.
 
 In order for ckb-auth to acutally verify the vailidity of the signature, we need to store the signature,
-the mode that used to sign the transactions and public keys (spend key followed by view key).
+the mode (only spend key mode is supported) that used to sign the transactions
+and public keys (spend key followed by view key).
 For example, to verify the signature with base65 encoding `3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea`
 which is signed by the spend key of monero account `41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc`
 we need to use the data whose hex encoding is

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -29,7 +29,7 @@ which outputs the message to sign
 ```
 157ea09579f09cf96307f6b23d6fd61c3cff123076d44c27e2e9bedf02135e87
 ```
-## Sign the message with litecoin-cli
+## Sign the message with monero-wallet-cli
 Following the steps below to set up a monero wallet, save above message to a binary file,
 e.g. running `printf "$(printf 157ea09579f09cf96307f6b23d6fd61c3cff123076d44c27e2e9bedf02135e87 | fold -w 2 | xargs -n 1 printf '\\x%s')" > ckb-auth-test-message`
 to save it to `ckb-auth-test-message`. To sign this message, finally run
@@ -45,7 +45,6 @@ Stripping prefix `SigV2`, this is the base64-encoded signature.
 ## Verify the signature with `verify` subcommand
 ```
 ckb-auth-cli monero verify -p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea -a 41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc -m spend
--p a55ec8bb5b93aaffefd754996cb097228839aad6 -s 3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea
 ```
 This commands return zero if and only if verification succeeded.
 
@@ -143,10 +142,11 @@ printf '%b' $(printf 42424242424242424242424242424242424242424242424242424242424
 Here `message` is a binary file with 32 repeated bytes of `0x42`. Change the command to suit your needs.
 
 ### Signing the message
-We can sign a message by running
+We can sign a message with spend key by running
 ```
 monero-wallet-cli --wallet-file ckb-auth-test-wallet --password pw sign message
 ```
+Signing with view key is also possible by passing `--view` to the sign command.
 
 Below is a sample output of the above command.
 

--- a/docs/monero.md
+++ b/docs/monero.md
@@ -169,3 +169,15 @@ SigV2DXdetxj9qiRe6PHsch9EwZVutb1FFR38ubNuM9ef8YPYcnjAisLWo4sLZMoT3g4Z48VRD3xAUsk
 Stripping the prefix `SigV2` of `SigV2DXdetxj9qiRe6PHsch9EwZVutb1FFR38ubNuM9ef8YPYcnjAisLWo4sLZMoT3g4Z48VRD3xAUsk1EcfthWcxnayW`,
 we get the base58 representation of the signature. Note that monero's implementation of base58 is different from bitcoin's.
 See [monero-rs/base58-monero](https://github.com/monero-rs/base58-monero) for how to manipulate monero base58 data programatically.
+
+In order for ckb-auth to acutally verify the vailidity of the signature, we need to store the signature,
+the mode that used to sign the transactions and public keys (spend key followed by view key).
+For example, to verify the signature with base65 encoding `3ZKheximq145tW14dshL17Jpqp2GJn296GfRnGqt3pMeaZU7xoEEAFr2Xm7Jc7xZjYWf6KhstZanA73to7uF6rea`
+which is signed by the spend key of monero account `41eBLjYsK28CJD5z2b7FojMCDg6vERASShVZqAvnsC9LhS7saG8CmMo5Rm92wgnT8wa6nJVu57MHHjmnoyvTpCG7NQ7dErc`
+we need to use the data whose hex encoding is
+```
+0f49fbc1bee9b7d31d3918a3753af5526a915e1f930198315da3e43bbd32f109c8a40ece34f42ff909263e16bb43f53bb14e5fe90de6c04f242b7c6a73ee320f00007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1bbcb8c902571ae1a777f7f07a023ecc5e3d83ba624d4b0ffb7eff79e8b5d10bd
+```
+where the first 64 bytes `0f49fbc1bee9b7d31d3918a3753af5526a915e1f930198315da3e43bbd32f109c8a40ece34f42ff909263e16bb43f53bb14e5fe90de6c04f242b7c6a73ee320f` are the signature itself,
+the 65th byte is the mode for siging (here `00`, which stands for signing with spend key),
+the next 64 bytes `007caf7a553a894389dd562115b17e78ba84a5c7692677f216c54385dc5c6ff1bbcb8c902571ae1a777f7f07a023ecc5e3d83ba624d4b0ffb7eff79e8b5d10bd` are the public spend key followed by public view key.

--- a/tests/auth_rust/Cargo.toml
+++ b/tests/auth_rust/Cargo.toml
@@ -25,6 +25,10 @@ mbedtls = "0.8.1"
 bitcoin = "0.30.0"
 base64 = "0.21.0"
 clap = "4.3.2"
+monero = { version = "0.18.2", features = ["serde"] }
+hex-literal = "0.4.1"
+tiny-keccak = "2.0.2"
+base58-monero = "1.0.0"
 log = { version = "0.4.14", features = ["std"] }
 bincode = "1.3.3"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/tests/auth_rust/src/lib.rs
+++ b/tests/auth_rust/src/lib.rs
@@ -82,6 +82,7 @@ pub enum AlgorithmType {
     Iso9796_2 = 9,
     Litecoin = 10,
     Cardano = 11,
+    Monero = 12,
     OwnerLock = 0xFC,
 }
 
@@ -733,6 +734,9 @@ pub fn auth_builder(t: AlgorithmType, official: bool) -> result::Result<Box<dyn 
         AlgorithmType::Cardano => {
             panic!("unsupport cardano")
         }
+        AlgorithmType::Monero => {
+            return Ok(MoneroAuth::new());
+        }
         AlgorithmType::OwnerLock => {
             return Ok(OwnerLockAuth::new());
         }
@@ -1247,6 +1251,126 @@ impl LitecoinDaemon {
         let mut command = Command::new(&self.client_executable);
         command.args(&self.common_arguments);
         command
+    }
+}
+
+#[derive(Clone)]
+pub struct MoneroAuth {
+    // A pair of spend key and view key. Both are needed the final hash to sign use their public
+    // keys.
+    pub key_pair: monero::KeyPair,
+    // Mode used by monero-wallet-cli to sign messages. Valid values are 0 and 1.
+    // Must be 0 if use spend key to sign transaction, 1 if use view key to sign transaction.
+    pub mode: u8,
+    // Network of monero used, necessary to obtain the address.
+    pub network: monero::Network,
+}
+impl MoneroAuth {
+    pub fn new() -> Box<MoneroAuth> {
+        fn get_random_key_pair() -> monero::KeyPair {
+            let mut rng = thread_rng();
+            let mut seed = vec![0; 32];
+            let spend_key = loop {
+                rng.fill(seed.as_mut_slice());
+                if let Ok(key) = monero::PrivateKey::from_slice(&seed) {
+                    break key;
+                }
+            };
+            let view_key = loop {
+                rng.fill(seed.as_mut_slice());
+                if let Ok(key) = monero::PrivateKey::from_slice(&seed) {
+                    break key;
+                }
+            };
+
+            let keypair = monero::KeyPair {
+                view: view_key,
+                spend: spend_key,
+            };
+            keypair
+        }
+
+        let key_pair = get_random_key_pair();
+        let mode = 0;
+        let network = monero::Network::Mainnet;
+        Box::new(MoneroAuth {
+            key_pair,
+            mode,
+            network,
+        })
+    }
+    pub fn get_address(&self) -> String {
+        monero::Address::from_keypair(self.network, &self.key_pair).to_string()
+    }
+}
+impl Auth for MoneroAuth {
+    fn get_pub_key_hash(&self) -> Vec<u8> {
+        let public_spend = monero::PublicKey::from_private_key(&self.key_pair.spend);
+        let public_view = monero::PublicKey::from_private_key(&self.key_pair.view);
+        let mut buff = BytesMut::with_capacity(1 + 32 * 2);
+        buff.put_u8(self.mode);
+        buff.put(public_spend.as_bytes());
+        buff.put(public_view.as_bytes());
+        let bytes = buff.freeze();
+        dbg!(hex::encode(&bytes));
+        Vec::from(&ckb_hash::blake2b_256(bytes)[..20])
+    }
+    fn get_algorithm_type(&self) -> u8 {
+        AlgorithmType::Monero as u8
+    }
+    fn convert_message(&self, message: &[u8; 32]) -> H256 {
+        H256::from(message.clone())
+    }
+    fn sign(&self, msg: &H256) -> Bytes {
+        let message_hex = hex::encode(msg.as_bytes());
+
+        let address = self.get_address();
+        let spend_key = hex::encode(self.key_pair.spend.to_bytes());
+        let view_key = hex::encode(self.key_pair.view.to_bytes());
+        let password = "pw";
+        // Click below link for instruction on creating a wallet non-interactively
+        // https://monero.stackexchange.com/questions/10385/creating-a-wallet-in-non-interactive-mode-using-monero-wallet-cli
+        let stdin_to_create_wallet = format!(
+            "{}\\\\n{}\\\\n{}\\\\n{}\\\\n{}\\\\n0\\\\nN\\\\n\\\\n",
+            address, spend_key, view_key, password, password,
+        );
+        let wallet_file_name = "ckb-auth-monero-test-wallet";
+        let message_file_name = "ckb-auth-monero-test-message";
+
+        let get_command = |command| {
+            let mut comm = Command::new("bash");
+            println!("Running shell command {command}");
+            comm.arg("-c").arg(command);
+            comm
+        };
+        let output = get_command(format!("for i in {wallet_file_name}* {message_file_name}; do rm -f $i; done; printf {stdin_to_create_wallet} | monero-wallet-cli --offline --generate-from-keys {wallet_file_name}; printf %b $(printf {message_hex} | fold -b2 | sed 's#^#\\\\x#') > {message_file_name}; echo {password} | monero-wallet-cli --offline --wallet-file {wallet_file_name} --password {password} sign {message_file_name}")).output().unwrap();
+        assert!(output.status.success());
+        let signature = std::str::from_utf8(&output.stdout)
+            .unwrap()
+            .lines()
+            .last()
+            .unwrap();
+        assert_eq!(&signature[..5], "SigV2");
+        // Note: must use base58_monero crate here. The output of other
+        // base58 library is imcompatible to monero's implementation of base58.
+        let signature = base58_monero::decode(&signature[5..]).unwrap();
+        assert_eq!(signature.len(), 64);
+
+        let mut data = BytesMut::with_capacity(signature.len() + 65);
+        data.put(signature.as_slice());
+        data.put_u8(self.mode);
+        let spend_pubkey = monero::PublicKey::from_private_key(&self.key_pair.spend);
+        let spend_pubkey = spend_pubkey.as_bytes();
+        data.put(spend_pubkey);
+        let view_pubkey = monero::PublicKey::from_private_key(&self.key_pair.view);
+        let view_pubkey = view_pubkey.as_bytes();
+        data.put(view_pubkey);
+        let bytes = data.freeze();
+        bytes
+    }
+    fn get_sign_size(&self) -> usize {
+        // #define MONERO_DATA_SIZE (MONERO_SIGNATURE_SIZE + 1 + MONERO_PUBKEY_SIZE * 2)
+        64 + 1 + 32 * 2
     }
 }
 

--- a/tests/auth_rust/src/tests/mod.rs
+++ b/tests/auth_rust/src/tests/mod.rs
@@ -14,6 +14,8 @@ use rand::{thread_rng, Rng};
 use sha3::{digest::generic_array::typenum::private::IsEqualPrivate, Digest, Keccak256};
 use std::sync::Arc;
 
+use hex_literal::hex;
+
 use crate::{
     assert_script_error, auth_builder, build_resolved_tx, debug_printer, gen_args, gen_tx,
     gen_tx_scripts_verifier, gen_tx_with_grouped_args, sign_tx, AlgorithmType, Auth,
@@ -289,6 +291,11 @@ fn litecoin_verify_official() {
         return;
     }
     unit_test_common_official(AlgorithmType::Litecoin);
+}
+
+#[test]
+fn monero_verify() {
+    unit_test_common(AlgorithmType::Monero);
 }
 
 #[test]

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -17,7 +17,7 @@ install:
 	wget 'https://github.com/XuJiandong/ckb-standalone-debugger/releases/download/ckb2023-0621/ckb-debugger-linux-x64.tar.gz'
 	tar zxvf ckb-debugger-linux-x64.tar.gz
 	mv ckb-debugger ~/.cargo/bin/ckb-debugger
-	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.10.0/capsule_v0.10.0_x86_64-linux.tar.gz'
-	tar xzvf capsule_v0.10.0_x86_64-linux.tar.gz
-	mv capsule_v0.10.0_x86_64-linux/capsule ~/.cargo/bin
+	wget https://github.com/nervosnetwork/capsule/releases/download/v0.9.2/capsule_v0.9.2_x86_64-linux.tar.gz
+	tar xzvf capsule*.tar.gz
+	mv capsule_*/capsule ~/.cargo/bin
 	cargo install moleculec --git https://github.com/nervosnetwork/molecule.git --rev 1306c29c529ab375e0368ffeb691bd8c7bbf0403

--- a/tests/auth_spawn_rust/Makefile
+++ b/tests/auth_spawn_rust/Makefile
@@ -14,5 +14,10 @@ auth-spawn-rust-success:
 	${CKB_DEBUGGER} --tx-file=tx.json -s lock
 
 install:
-	cargo install --locked --branch ckb2023 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
-	cargo install ckb-capsule --git https://github.com/nervosnetwork/capsule.git --tag v0.9.2
+	wget 'https://github.com/XuJiandong/ckb-standalone-debugger/releases/download/ckb2023-0621/ckb-debugger-linux-x64.tar.gz'
+	tar zxvf ckb-debugger-linux-x64.tar.gz
+	mv ckb-debugger ~/.cargo/bin/ckb-debugger
+	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.10.0/capsule_v0.10.0_x86_64-linux.tar.gz'
+	tar xzvf capsule_v0.10.0_x86_64-linux.tar.gz
+	mv capsule_v0.10.0_x86_64-linux/capsule ~/.cargo/bin
+	cargo install moleculec --git https://github.com/nervosnetwork/molecule.git --rev 1306c29c529ab375e0368ffeb691bd8c7bbf0403

--- a/tools/ckb-auth-cli/Cargo.lock
+++ b/tools/ckb-auth-cli/Cargo.lock
@@ -103,6 +103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base58-monero"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d079cdf47e1ca75554200bb2f30bff5a5af16964cac4a566b18de9a5d48db2b"
+dependencies = [
+ "thiserror",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +329,7 @@ name = "ckb-auth-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base58-monero",
  "base64",
  "bs58",
  "ckb-auth-rs",
@@ -329,6 +340,7 @@ dependencies = [
  "clap",
  "hex",
  "lazy_static",
+ "monero",
  "serde_json",
 ]
 
@@ -337,6 +349,7 @@ name = "ckb-auth-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base58-monero",
  "base64",
  "bincode",
  "bitcoin",
@@ -353,9 +366,11 @@ dependencies = [
  "clap",
  "dyn-clone",
  "hex",
+ "hex-literal 0.4.1",
  "lazy_static",
  "log",
  "mbedtls",
+ "monero",
  "rand 0.6.5",
  "secp256k1 0.22.2",
  "serde",
@@ -363,6 +378,7 @@ dependencies = [
  "sha3",
  "sparse-merkle-tree",
  "tempdir",
+ "tiny-keccak",
  "which",
 ]
 
@@ -796,6 +812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +832,20 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "serde",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "derive_more"
@@ -889,6 +925,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +971,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -972,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1050,18 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex_lit"
@@ -1225,6 +1305,24 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "faster-hex",
+]
+
+[[package]]
+name = "monero"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8965a7510c5d9389e2086e406c292d6bbecac099eef195be55a2d2043448b9"
+dependencies = [
+ "base58-monero",
+ "curve25519-dalek",
+ "fixed-hash",
+ "hex",
+ "hex-literal 0.3.4",
+ "sealed",
+ "serde",
+ "serde-big-array",
+ "thiserror",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1476,12 +1574,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "rand_pcg 0.2.1",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1505,6 +1614,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,7 +1644,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -1668,6 +1796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1869,18 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sealed"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5e421024b5e5edfbaa8e60ecf90bda9dbffc602dbb230e6028763f85f0c68c"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1827,6 +1973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,10 +2054,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -1968,6 +2135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2218,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2217,3 +2405,9 @@ dependencies = [
  "bit-vec 0.5.1",
  "num-bigint",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/tools/ckb-auth-cli/Cargo.toml
+++ b/tools/ckb-auth-cli/Cargo.toml
@@ -18,3 +18,4 @@ bs58 = "0.5.0"
 anyhow = "1.0.71"
 base64 = "0.21.0"
 serde_json = "1.0"
+monero = { version = "0.18.2", features = ["serde"] }

--- a/tools/ckb-auth-cli/Cargo.toml
+++ b/tools/ckb-auth-cli/Cargo.toml
@@ -19,3 +19,4 @@ anyhow = "1.0.71"
 base64 = "0.21.0"
 serde_json = "1.0"
 monero = { version = "0.18.2", features = ["serde"] }
+base58-monero = "1.0.0"

--- a/tools/ckb-auth-cli/src/litecoin.rs
+++ b/tools/ckb-auth-cli/src/litecoin.rs
@@ -127,7 +127,7 @@ fn get_pubkey_hash_by_args(sub_matches: &ArgMatches) -> Result<[u8; 20], Error> 
 fn get_pub_key_hash_from_address(address: &str) -> Result<Vec<u8>, Error> {
     // base58 -d <<< mhknqLHQGWDXuLsPdzab8nA4jD3fMdVYS2 | xxd -s 1 -l 20 -p
     let bytes = bs58::decode(&address).into_vec()?;
-    return Ok(bytes[1..21].into());
+    Ok(bytes[1..21].into())
 }
 
 fn decode_string(s: &str, encoding: &str) -> Result<Vec<u8>, Error> {

--- a/tools/ckb-auth-cli/src/main.rs
+++ b/tools/ckb-auth-cli/src/main.rs
@@ -90,6 +90,6 @@ fn main() -> Result<(), Error> {
         Some(("parse", operate_mathches)) => subcommand.parse(operate_mathches),
         Some(("generate", operate_mathches)) => subcommand.generate(operate_mathches),
         Some(("verify", operate_mathches)) => subcommand.verify(operate_mathches),
-        _ => return Err(anyhow!("unsupported operate")),
+        _ => Err(anyhow!("unsupported operate")),
     }
 }

--- a/tools/ckb-auth-cli/src/main.rs
+++ b/tools/ckb-auth-cli/src/main.rs
@@ -2,6 +2,7 @@ mod auth_script;
 mod cardano;
 mod litecoin;
 mod monero;
+mod utils;
 
 use crate::monero::MoneroLockArgs;
 use cardano::CardanoLockArgs;

--- a/tools/ckb-auth-cli/src/main.rs
+++ b/tools/ckb-auth-cli/src/main.rs
@@ -1,7 +1,9 @@
 mod auth_script;
 mod cardano;
 mod litecoin;
+mod monero;
 
+use crate::monero::MoneroLockArgs;
 use cardano::CardanoLockArgs;
 use litecoin::LitecoinLockArgs;
 
@@ -70,6 +72,7 @@ fn main() -> Result<(), Error> {
     let block_chain_args = [
         Box::new(LitecoinLockArgs {}) as Box<dyn BlockChainArgs>,
         Box::new(CardanoLockArgs {}) as Box<dyn BlockChainArgs>,
+        Box::new(MoneroLockArgs {}) as Box<dyn BlockChainArgs>,
     ];
 
     let matches = cli(block_chain_args.as_slice()).get_matches();

--- a/tools/ckb-auth-cli/src/monero.rs
+++ b/tools/ckb-auth-cli/src/monero.rs
@@ -132,8 +132,7 @@ impl BlockChain for MoneroLock {
             .get_one::<String>("signature")
             .expect("get verify signature");
 
-        let signature: Vec<u8> = decode_string(signature, "base64")?;
-        dbg!(hex::encode(&signature));
+        let signature: Vec<u8> = decode_string(signature, "base58_monero")?;
 
         let address = operate_matches
             .get_one::<String>("address")
@@ -152,13 +151,11 @@ impl BlockChain for MoneroLock {
             &address.public_view,
             mode == MoneroMode::Spend,
         );
-        dbg!(hex::encode(&pub_key_info));
         let mut data = BytesMut::with_capacity(signature.len() + pub_key_info.len());
         data.put(signature.as_slice());
         data.put(pub_key_info.as_slice());
         let signature = data.freeze();
 
-        dbg!(hex::encode(&signature));
         let algorithm_type = AlgorithmType::Monero;
         let run_type = EntryCategoryType::Exec;
         let auth = auth_builder(algorithm_type, false).unwrap();

--- a/tools/ckb-auth-cli/src/monero.rs
+++ b/tools/ckb-auth-cli/src/monero.rs
@@ -7,14 +7,14 @@ use ckb_auth_rs::{
     gen_tx_with_pub_key_hash, get_message_to_sign, set_signature, AlgorithmType, DummyDataLoader,
     EntryCategoryType, MoneroAuth, TestConfig, MAX_CYCLES,
 };
-use ckb_script::TransactionScriptsVerifier;
+
 use ckb_types::bytes::{BufMut, BytesMut};
 use clap::{arg, ArgMatches, Command};
 use core::str::FromStr;
 use hex::encode;
 use monero_rs::Address;
-use std::sync::Arc;
 
+#[allow(dead_code)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MoneroMode {
     Spend,
@@ -162,9 +162,9 @@ impl BlockChain for MoneroLock {
         let config = TestConfig::new(&auth, run_type, 1);
         let mut data_loader = DummyDataLoader::new();
         let tx = gen_tx_with_pub_key_hash(&mut data_loader, &config, pubkey_hash.to_vec());
-        let signature = signature.into();
+        let signature = signature;
         let tx = set_signature(tx, &signature);
-        let resolved_tx = build_resolved_tx(&data_loader, &tx);
+        let _resolved_tx = build_resolved_tx(&data_loader, &tx);
 
         let mut verifier = gen_tx_scripts_verifier(tx, data_loader);
         verifier.set_debug_printer(debug_printer);

--- a/tools/ckb-auth-cli/src/monero.rs
+++ b/tools/ckb-auth-cli/src/monero.rs
@@ -1,0 +1,181 @@
+extern crate monero as monero_rs;
+
+use super::{BlockChain, BlockChainArgs};
+use anyhow::{anyhow, Error};
+use ckb_auth_rs::{
+    auth_builder, build_resolved_tx, debug_printer, gen_tx_with_pub_key_hash, get_message_to_sign,
+    set_signature, AlgorithmType, DummyDataLoader, EntryCategoryType, MoneroAuth, TestConfig,
+    MAX_CYCLES,
+};
+use ckb_script::TransactionScriptsVerifier;
+use clap::{arg, ArgMatches, Command};
+use core::str::FromStr;
+use hex::{decode, encode};
+use monero_rs::Address;
+use std::sync::Arc;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum MoneroMode {
+    Spend,
+    View,
+}
+
+impl FromStr for MoneroMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "spend" => Ok(MoneroMode::Spend),
+            "view" => Ok(MoneroMode::View),
+            _ => Err(anyhow!("Only spend and view mode are supported")),
+        }
+    }
+}
+
+pub struct MoneroLockArgs {}
+
+impl BlockChainArgs for MoneroLockArgs {
+    fn block_chain_name(&self) -> &'static str {
+        "monero"
+    }
+    fn reg_parse_args(&self, cmd: Command) -> Command {
+        cmd.arg(arg!(-a --address <ADDRESS> "The address to parse"))
+            .arg(
+                arg!(-m --mode <MODE> "The mode to sign transactions (must be spend or view)")
+                    .required(false),
+            )
+    }
+    fn reg_generate_args(&self, cmd: Command) -> Command {
+        cmd.arg(arg!(-p --pubkeyhash <PUBKEYHASH> "The pubkey hash to include in the message"))
+    }
+    fn reg_verify_args(&self, cmd: Command) -> Command {
+        cmd .arg(arg!(-a --address <ADDRESS> "The pubkey address whose hash verify against"))
+      .arg(arg!(-p --pubkeyhash <PUBKEYHASH> "The pubkey hash to verify against"))
+      .arg(arg!(-s --signature <SIGNATURE> "The signature to verify"))
+      .arg(arg!(-e --encoding <ENCODING> "The encoding of the signature (must be hex or base64)"))
+    }
+
+    fn get_block_chain(&self) -> Box<dyn BlockChain> {
+        Box::new(MoneroLock {})
+    }
+}
+
+pub struct MoneroLock {}
+
+impl BlockChain for MoneroLock {
+    fn parse(&self, operate_mathches: &ArgMatches) -> Result<(), Error> {
+        let address = operate_mathches
+            .get_one::<String>("address")
+            .expect("get parse address");
+
+        let address: Address = FromStr::from_str(address)?;
+
+        let mode = operate_mathches
+            .get_one::<String>("mode")
+            .map(String::as_str)
+            .unwrap_or("spend");
+
+        let mode: MoneroMode = FromStr::from_str(mode)?;
+        let pubkey_hash = MoneroAuth::get_pub_key_hash(
+            &address.public_spend,
+            &address.public_view,
+            mode == MoneroMode::Spend,
+        );
+
+        println!("{}", encode(pubkey_hash));
+
+        Ok(())
+    }
+
+    fn generate(&self, operate_mathches: &ArgMatches) -> Result<(), Error> {
+        let pubkey_hash = get_pubkey_hash_by_args(operate_mathches)?;
+
+        let run_type = EntryCategoryType::Exec;
+        // Note that we must set the official parameter of auth_builder to be true here.
+        // The difference between official=true and official=false is that the later
+        // convert the message to a form that can be signed directly with secp256k1.
+        // This is not intended as the monero-cli will do the conversion internally,
+        // and then sign the converted message. With official set to be true, we don't
+        // do this kind of conversion in the auth data structure.
+        let auth = auth_builder(AlgorithmType::Monero, true).unwrap();
+        let config = TestConfig::new(&auth, run_type, 1);
+        let mut data_loader = DummyDataLoader::new();
+        let tx = gen_tx_with_pub_key_hash(&mut data_loader, &config, pubkey_hash.to_vec());
+        let message_to_sign = get_message_to_sign(tx, &config);
+
+        println!("{}", encode(message_to_sign.as_bytes()));
+        Ok(())
+    }
+
+    fn verify(&self, operate_mathches: &ArgMatches) -> Result<(), Error> {
+        let pubkey_hash = get_pubkey_hash_by_args(operate_mathches)?;
+
+        let signature = operate_mathches
+            .get_one::<String>("signature")
+            .expect("get verify signature");
+
+        let encoding = operate_mathches
+            .get_one::<String>("encoding")
+            .expect("get verify encoding");
+
+        let signature: Vec<u8> = decode_string(signature, encoding)?;
+
+        let algorithm_type = AlgorithmType::Monero;
+        let run_type = EntryCategoryType::Exec;
+        let auth = auth_builder(algorithm_type, false).unwrap();
+        let config = TestConfig::new(&auth, run_type, 1);
+        let mut data_loader = DummyDataLoader::new();
+        let tx = gen_tx_with_pub_key_hash(&mut data_loader, &config, pubkey_hash.to_vec());
+        let signature = signature.into();
+        let tx = set_signature(tx, &signature);
+        let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+        let mut verifier =
+            TransactionScriptsVerifier::new(Arc::new(resolved_tx), data_loader.clone());
+        verifier.set_debug_printer(debug_printer);
+        let result = verifier.verify(MAX_CYCLES);
+        if result.is_err() {
+            dbg!(result.unwrap_err());
+            panic!("Verification failed");
+        }
+        println!("Signature verification succeeded!");
+
+        Ok(())
+    }
+}
+
+fn get_pubkey_hash_by_args(sub_matches: &ArgMatches) -> Result<[u8; 20], Error> {
+    let pubkey_hash: Option<&String> = sub_matches.get_one::<String>("pubkeyhash");
+    let pubkey_hash: [u8; 20] = if pubkey_hash.is_some() {
+        decode(pubkey_hash.unwrap())
+            .expect("decode pubkey")
+            .try_into()
+            .unwrap()
+    } else {
+        let address = sub_matches
+            .get_one::<String>("address")
+            .expect("get generate address");
+        get_pub_key_hash_from_address(address)?
+            .try_into()
+            .expect("address buf to [u8; 20]")
+    };
+
+    Ok(pubkey_hash)
+}
+
+fn get_pub_key_hash_from_address(address: &str) -> Result<Vec<u8>, Error> {
+    // base58 -d <<< mhknqLHQGWDXuLsPdzab8nA4jD3fMdVYS2 | xxd -s 1 -l 20 -p
+    let bytes = bs58::decode(&address).into_vec()?;
+    return Ok(bytes[1..21].into());
+}
+
+fn decode_string(s: &str, encoding: &str) -> Result<Vec<u8>, Error> {
+    match encoding {
+        "hex" => Ok(hex::decode(s)?),
+        "base64" => {
+            use base64::{engine::general_purpose, Engine as _};
+            Ok(general_purpose::STANDARD.decode(s)?)
+        }
+        _ => Err(anyhow!("Unknown encoding {}", encoding)),
+    }
+}

--- a/tools/ckb-auth-cli/src/monero.rs
+++ b/tools/ckb-auth-cli/src/monero.rs
@@ -29,8 +29,8 @@ impl FromStr for MoneroMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
             "spend" => Ok(MoneroMode::Spend),
-            "view" => Ok(MoneroMode::View),
-            _ => Err(anyhow!("Only spend and view mode are supported")),
+            "view" => Err(anyhow!("View mode is currently not supported, use spend instead")),
+            _ => Err(anyhow!("Only spend mode is supported")),
         }
     }
 }
@@ -44,7 +44,7 @@ impl BlockChainArgs for MoneroLockArgs {
     fn reg_parse_args(&self, cmd: Command) -> Command {
         cmd.arg(arg!(-a --address <ADDRESS> "The address to parse"))
             .arg(
-                arg!(-m --mode <MODE> "The mode to sign transactions (must be spend or view)")
+                arg!(-m --mode <MODE> "The mode to sign transactions (currently the only valid value is spend)")
                     .required(false),
             )
     }
@@ -54,7 +54,7 @@ impl BlockChainArgs for MoneroLockArgs {
     fn reg_verify_args(&self, cmd: Command) -> Command {
         cmd.arg(arg!(-a --address <ADDRESS> "The pubkey address whose hash verify against"))
             .arg(
-                arg!(-m --mode <MODE> "The mode to sign transactions (must be spend or view)")
+                arg!(-m --mode <MODE> "The mode to sign transactions (currently the only valid value is spend)")
                     .required(false),
             )
             .arg(arg!(-p --pubkeyhash <PUBKEYHASH> "The pubkey hash to include in the message"))

--- a/tools/ckb-auth-cli/src/utils.rs
+++ b/tools/ckb-auth-cli/src/utils.rs
@@ -1,0 +1,12 @@
+use anyhow::{anyhow, Error};
+
+pub(crate) fn decode_string(s: &str, encoding: &str) -> Result<Vec<u8>, Error> {
+    match encoding {
+        "hex" => Ok(hex::decode(s)?),
+        "base64" => {
+            use base64::{engine::general_purpose, Engine as _};
+            Ok(general_purpose::STANDARD.decode(s)?)
+        }
+        _ => Err(anyhow!("Unknown encoding {}", encoding)),
+    }
+}

--- a/tools/ckb-auth-cli/src/utils.rs
+++ b/tools/ckb-auth-cli/src/utils.rs
@@ -7,6 +7,10 @@ pub(crate) fn decode_string(s: &str, encoding: &str) -> Result<Vec<u8>, Error> {
             use base64::{engine::general_purpose, Engine as _};
             Ok(general_purpose::STANDARD.decode(s)?)
         }
+        "base58_monero" => {
+            let b = base58_monero::decode(&s)?;
+            Ok(b)
+        }
         _ => Err(anyhow!("Unknown encoding {}", encoding)),
     }
 }

--- a/tools/ckb-auth-cli/src/utils.rs
+++ b/tools/ckb-auth-cli/src/utils.rs
@@ -8,7 +8,7 @@ pub(crate) fn decode_string(s: &str, encoding: &str) -> Result<Vec<u8>, Error> {
             Ok(general_purpose::STANDARD.decode(s)?)
         }
         "base58_monero" => {
-            let b = base58_monero::decode(&s)?;
+            let b = base58_monero::decode(s)?;
             Ok(b)
         }
         _ => Err(anyhow!("Unknown encoding {}", encoding)),


### PR DESCRIPTION
Require the PR [Add monero signature support by contrun · Pull Request #1 · nervosnetwork/ed25519](https://github.com/nervosnetwork/ed25519/pull/1) from ed25519 repo. Currently ckb-auth-cli usages will be added in a separated PR.