### PR TITLE
ignore tools/ckb-auth-cli in workspace Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["examples/auth-rust-demo"]
-exclude = ["tests"]
+exclude = ["tests", "tools/ckb-auth-cli"]
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
`tools/ckb-auth-cli` needs to be ignored from workspace Cargo.toml file.

Currently, `cd tools/ckb-auth-cli/; cargo run` outputs

```
error: current package believes it's in a workspace when it's not:
current:   /home/e/Workspace/ckb-auth/tools/ckb-auth-cli/Cargo.toml
workspace: /home/e/Workspace/ckb-auth/Cargo.toml

this may be fixable by adding `tools/ckb-auth-cli` to the `workspace.members` array of the manifest located at: /home/e/Workspace/ckb-auth/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```